### PR TITLE
Fix CSV fetch numeric types

### DIFF
--- a/backend/app/fetch_data.py
+++ b/backend/app/fetch_data.py
@@ -6,6 +6,9 @@ from dotenv import load_dotenv
 
 load_dotenv()
 API_KEY = os.getenv("ALPHAVANTAGE_API_KEY")
+
+if not API_KEY:
+    raise EnvironmentError("ALPHAVANTAGE_API_KEY environment variable not set")
 URL = "https://www.alphavantage.co/query"
 
 def fetch_daily(symbol: str, outputsize: str = "compact") -> pd.DataFrame:
@@ -30,6 +33,7 @@ def fetch_daily(symbol: str, outputsize: str = "compact") -> pd.DataFrame:
         "4. close": "Close",
         "5. volume": "Volume"
     })
+    df = df.apply(pd.to_numeric)
     df.index = pd.to_datetime(df.index)
     df = df.sort_index()
     return df

--- a/backend/tests/test_fetch_data.py
+++ b/backend/tests/test_fetch_data.py
@@ -1,0 +1,28 @@
+from unittest.mock import patch, MagicMock
+import pytest
+pd = pytest.importorskip("pandas")
+from app.fetch_data import fetch_daily
+
+sample_response = {
+    "Time Series (Daily)": {
+        "2023-01-02": {
+            "1. open": "10.0",
+            "2. high": "12.0",
+            "3. low": "9.5",
+            "4. close": "11.0",
+            "5. volume": "1000"
+        }
+    }
+}
+
+class MockResponse:
+    def json(self):
+        return sample_response
+
+@patch('app.fetch_data.requests.get')
+def test_fetch_daily_numeric(mock_get):
+    mock_get.return_value = MockResponse()
+    df = fetch_daily('MSFT')
+    assert df.loc[pd.Timestamp('2023-01-02'), 'Open'] == 10.0
+    assert df.dtypes['Open'] == float
+


### PR DESCRIPTION
## Summary
- enforce ALPHAVANTAGE_API_KEY exists
- convert fetched values to numeric
- add test for numeric conversion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68600eb1ad6883259833c4db46d94e4c